### PR TITLE
Move build-option methods from commands into builder

### DIFF
--- a/builder/build_test.go
+++ b/builder/build_test.go
@@ -1,7 +1,10 @@
 package builder
 
 import (
+	"strings"
 	"testing"
+
+	"github.com/openfaas/faas-cli/stack"
 )
 
 func Test_buildFlagSlice(t *testing.T) {
@@ -13,6 +16,7 @@ func Test_buildFlagSlice(t *testing.T) {
 		httpProxy     string
 		httpsProxy    string
 		buildArgMap   map[string]string
+		buildPackages []string
 		expectedSlice []string
 	}{
 		{
@@ -22,6 +26,7 @@ func Test_buildFlagSlice(t *testing.T) {
 			httpProxy:     "",
 			httpsProxy:    "",
 			buildArgMap:   make(map[string]string),
+			buildPackages: []string{},
 			expectedSlice: []string{"--no-cache"},
 		},
 		{
@@ -31,6 +36,7 @@ func Test_buildFlagSlice(t *testing.T) {
 			httpProxy:     "",
 			httpsProxy:    "",
 			buildArgMap:   make(map[string]string),
+			buildPackages: []string{},
 			expectedSlice: []string{"--no-cache", "--squash"},
 		},
 		{
@@ -40,6 +46,7 @@ func Test_buildFlagSlice(t *testing.T) {
 			httpProxy:     "192.168.0.1",
 			httpsProxy:    "",
 			buildArgMap:   make(map[string]string),
+			buildPackages: []string{},
 			expectedSlice: []string{"--no-cache", "--squash", "--build-arg", "http_proxy=192.168.0.1"},
 		},
 		{
@@ -49,6 +56,7 @@ func Test_buildFlagSlice(t *testing.T) {
 			httpProxy:     "",
 			httpsProxy:    "127.0.0.1",
 			buildArgMap:   make(map[string]string),
+			buildPackages: []string{},
 			expectedSlice: []string{"--no-cache", "--squash", "--build-arg", "https_proxy=127.0.0.1"},
 		},
 		{
@@ -58,6 +66,7 @@ func Test_buildFlagSlice(t *testing.T) {
 			httpProxy:     "192.168.0.1",
 			httpsProxy:    "127.0.0.1",
 			buildArgMap:   make(map[string]string),
+			buildPackages: []string{},
 			expectedSlice: []string{"--no-cache", "--squash", "--build-arg", "http_proxy=192.168.0.1", "--build-arg", "https_proxy=127.0.0.1"},
 		},
 		{
@@ -67,6 +76,7 @@ func Test_buildFlagSlice(t *testing.T) {
 			httpProxy:     "192.168.0.1",
 			httpsProxy:    "127.0.0.1",
 			buildArgMap:   make(map[string]string),
+			buildPackages: []string{},
 			expectedSlice: []string{"--build-arg", "http_proxy=192.168.0.1", "--build-arg", "https_proxy=127.0.0.1"},
 		},
 		{
@@ -78,6 +88,7 @@ func Test_buildFlagSlice(t *testing.T) {
 			buildArgMap: map[string]string{
 				"muppet": "ernie",
 			},
+			buildPackages: []string{},
 			expectedSlice: []string{"--build-arg", "muppet=ernie"},
 		},
 		{
@@ -89,6 +100,7 @@ func Test_buildFlagSlice(t *testing.T) {
 			buildArgMap: map[string]string{
 				"muppets": "burt and ernie",
 			},
+			buildPackages: []string{},
 			expectedSlice: []string{"--build-arg", "muppets=burt and ernie"},
 		},
 		{
@@ -101,6 +113,7 @@ func Test_buildFlagSlice(t *testing.T) {
 				"muppets":    "burt and ernie",
 				"playschool": "Jemima",
 			},
+			buildPackages: []string{},
 			expectedSlice: []string{"--build-arg", "muppets=burt and ernie", "--build-arg", "playschool=Jemima"},
 		},
 		{
@@ -113,6 +126,7 @@ func Test_buildFlagSlice(t *testing.T) {
 				"muppets":    "burt and ernie",
 				"playschool": "Jemima",
 			},
+			buildPackages: []string{},
 			expectedSlice: []string{"--no-cache", "--squash", "--build-arg", "muppets=burt and ernie", "--build-arg", "playschool=Jemima"},
 		},
 	}
@@ -121,7 +135,7 @@ func Test_buildFlagSlice(t *testing.T) {
 
 		t.Run(test.title, func(t *testing.T) {
 
-			flagSlice := buildFlagSlice(test.nocache, test.squash, test.httpProxy, test.httpsProxy, test.buildArgMap)
+			flagSlice := buildFlagSlice(test.nocache, test.squash, test.httpProxy, test.httpsProxy, test.buildArgMap, test.buildPackages)
 
 			if len(flagSlice) != len(test.expectedSlice) {
 				t.Errorf("Slices differ in size - wanted: %d, found %d", len(test.expectedSlice), len(flagSlice))
@@ -142,3 +156,201 @@ func Test_buildFlagSlice(t *testing.T) {
 	}
 
 }
+
+func Test_getPackages(t *testing.T) {
+	var buildOpts = []struct {
+		title                 string
+		availableBuildOptions []stack.BuildOption
+		requestedBuildOptions []string
+		expectedPackages      []string
+	}{
+		{
+			title: "Single Option",
+			availableBuildOptions: []stack.BuildOption{
+				stack.BuildOption{Name: "dev",
+					Packages: []string{"jq", "hw", "ke"}},
+			},
+			requestedBuildOptions: []string{"dev"},
+			expectedPackages:      []string{"jq", "hw", "ke"},
+		},
+		{
+			title: "Two Options one chosen",
+			availableBuildOptions: []stack.BuildOption{
+				stack.BuildOption{Name: "dev",
+					Packages: []string{"jq", "hw", "ke"}},
+				stack.BuildOption{Name: "debug",
+					Packages: []string{"lr", "kt", "jy"}},
+			},
+			requestedBuildOptions: []string{"dev"},
+			expectedPackages:      []string{"jq", "hw", "ke"},
+		},
+		{
+			title: "Two Options two chosen",
+			availableBuildOptions: []stack.BuildOption{
+				stack.BuildOption{Name: "dev",
+					Packages: []string{"jq", "hw", "ke"}},
+				stack.BuildOption{Name: "debug",
+					Packages: []string{"lr", "kt", "jy"}},
+			},
+			requestedBuildOptions: []string{"dev", "debug"},
+			expectedPackages:      []string{"jq", "hw", "ke", "lr", "kt", "jy"},
+		},
+		{
+			title: "Two Options two chosen with overlaps",
+			availableBuildOptions: []stack.BuildOption{
+				stack.BuildOption{Name: "dev",
+					Packages: []string{"jq", "hw", "ke"}},
+				stack.BuildOption{Name: "debug",
+					Packages: []string{"lr", "jq", "hw"}},
+			},
+			requestedBuildOptions: []string{"dev", "debug"},
+			expectedPackages:      []string{"jq", "hw", "ke", "lr"},
+		},
+	}
+	for _, test := range buildOpts {
+
+		t.Run(test.title, func(t *testing.T) {
+
+			buildOptPackages, _ := getPackages(test.availableBuildOptions, test.requestedBuildOptions)
+
+			if len(buildOptPackages) != len(test.expectedPackages) {
+				t.Errorf("Slices differ in size - wanted: %d, found %d", len(test.expectedPackages), len(buildOptPackages))
+			}
+			for _, expectedOptPackage := range test.expectedPackages {
+				found := false
+				for _, buildOptPackage := range buildOptPackages {
+					if buildOptPackage == expectedOptPackage {
+						found = true
+						break
+					}
+				}
+				if found == false {
+
+					t.Errorf("Slices differ in values  - wanted: %s, found %s", strings.Join(test.expectedPackages, " "), strings.Join(buildOptPackages, " "))
+				}
+			}
+		})
+	}
+}
+
+func Test_deDuplicate(t *testing.T) {
+	var stringOpts = []struct {
+		title           string
+		inputStrings    []string
+		expectedStrings []string
+	}{
+		{
+			title:           "No Duplicates",
+			inputStrings:    []string{"jq", "hw", "ke"},
+			expectedStrings: []string{"jq", "hw", "ke"},
+		},
+		{
+			title:           "Duplicates",
+			inputStrings:    []string{"jq", "hw", "ke", "jq", "hw", "ke"},
+			expectedStrings: []string{"jq", "hw", "ke"},
+		},
+	}
+	for _, test := range stringOpts {
+
+		t.Run(test.title, func(t *testing.T) {
+
+			uniqueStrings := deDuplicate(test.inputStrings)
+
+			if len(uniqueStrings) != len(test.expectedStrings) {
+				t.Errorf("Slices differ in size - wanted: %d, found %d", len(test.expectedStrings), len(uniqueStrings))
+			}
+
+			for _, expectedString := range test.expectedStrings {
+
+				found := false
+
+				for _, uniqueString := range uniqueStrings {
+
+					if expectedString == uniqueString {
+						found = true
+						break
+					}
+				}
+				if found == false {
+
+					t.Errorf("Slices differ in values  - wanted: %s, found %s", strings.Join(test.expectedStrings, " "), strings.Join(uniqueStrings, " "))
+				}
+			}
+		})
+	}
+}
+
+/*func Test_validateBuildOption(t *testing.T) {
+
+	buildOptions := []struct {
+		buildOption           string
+		expectedBuildArgValue string
+	}{
+		{
+			buildOption:           "dev",
+			expectedBuildArgValue: "ADDITIONAL_PACKAGE=make automake gcc g++ subversion python3-dev musl-dev libffi-dev",
+		},
+
+		{
+			buildOption:           "undefined",
+			expectedBuildArgValue: "",
+		},
+	}
+
+	os.MkdirAll("template/python3", os.ModePerm)
+	python3_template_yml, err := os.Create("template/python3/template.yml")
+	if err != nil {
+		t.Errorf("Error creating template/python3/template.yml file")
+	}
+
+	_, err = python3_template_yml.WriteString("language: python3\n" +
+		"fprocess: python3 index.py\n" +
+		"build_options: \n" +
+		"  - name: dev\n" +
+		"    packages: \n" +
+		"      - make\n" +
+		"      - automake\n" +
+		"      - gcc\n" +
+		"      - g++\n" +
+		"      - subversion\n" +
+		"      - python3-dev\n" +
+		"      - musl-dev\n" +
+		"      - libffi-dev\n")
+
+	if err != nil {
+		t.Errorf("Error writing to template/python3/template.yml file")
+	}
+
+	os.MkdirAll("template/unsupported", os.ModePerm)
+	unsupported_template_yml, err := os.Create("template/unsupported/template.yml")
+	if err != nil {
+		t.Errorf("Error creating template/unsupported/template.yml file")
+	}
+
+	_, err = unsupported_template_yml.WriteString("language: python3\n" +
+		"fprocess: python3 index.py\n")
+
+	if err != nil {
+		t.Errorf("Error writing to template/pythunsupportedon3/template.yml file")
+	}
+
+	for _, test := range buildOptions {
+		t.Run(test.buildOption, func(t *testing.T) {
+			res, _, _ := validateBuildOption(test.buildOption, "python3")
+			_, isValid, _ := validateBuildOption(test.buildOption, "unsupported")
+
+			if res != test.expectedBuildArgValue {
+				t.Errorf("validateBuildOption failed for build-option %s. Expected to return %s, but returned %s",
+					test.buildOption, test.expectedBuildArgValue, res)
+			}
+
+			if isValid && test.buildOption == "dev" {
+				t.Errorf("validateBuildOption failed for build-option %s and unsupported language. Expected validation to fail, but it was successful",
+					test.buildOption)
+			}
+		})
+	}
+
+	os.RemoveAll("template")
+}
+*/

--- a/commands/build_test.go
+++ b/commands/build_test.go
@@ -4,7 +4,6 @@
 package commands
 
 import (
-	"os"
 	"testing"
 )
 
@@ -74,78 +73,4 @@ func Test_parseBuildArgs_MultipleSeparators(t *testing.T) {
 		t.Errorf("value for 'k', want: %s got: %s", "v=z", mapped["k"])
 		t.Fail()
 	}
-}
-
-func Test_validateBuildOption(t *testing.T) {
-
-	buildOptions := []struct {
-		buildOption           string
-		expectedBuildArgValue string
-	}{
-		{
-			buildOption:           "dev",
-			expectedBuildArgValue: "ADDITIONAL_PACKAGE=make automake gcc g++ subversion python3-dev musl-dev libffi-dev",
-		},
-
-		{
-			buildOption:           "undefined",
-			expectedBuildArgValue: "",
-		},
-	}
-
-	os.MkdirAll("template/python3", os.ModePerm)
-	python3_template_yml, err := os.Create("template/python3/template.yml")
-	if err != nil {
-		t.Errorf("Error creating template/python3/template.yml file")
-	}
-
-	_, err = python3_template_yml.WriteString("language: python3\n" +
-		"fprocess: python3 index.py\n" +
-		"build_options: \n" +
-		"  - name: dev\n" +
-		"    packages: \n" +
-		"      - make\n" +
-		"      - automake\n" +
-		"      - gcc\n" +
-		"      - g++\n" +
-		"      - subversion\n" +
-		"      - python3-dev\n" +
-		"      - musl-dev\n" +
-		"      - libffi-dev\n")
-
-	if err != nil {
-		t.Errorf("Error writing to template/python3/template.yml file")
-	}
-
-	os.MkdirAll("template/unsupported", os.ModePerm)
-	unsupported_template_yml, err := os.Create("template/unsupported/template.yml")
-	if err != nil {
-		t.Errorf("Error creating template/unsupported/template.yml file")
-	}
-
-	_, err = unsupported_template_yml.WriteString("language: python3\n" +
-		"fprocess: python3 index.py\n")
-
-	if err != nil {
-		t.Errorf("Error writing to template/pythunsupportedon3/template.yml file")
-	}
-
-	for _, test := range buildOptions {
-		t.Run(test.buildOption, func(t *testing.T) {
-			res, _, _ := validateBuildOption(test.buildOption, "python3")
-			_, isValid, _ := validateBuildOption(test.buildOption, "unsupported")
-
-			if res != test.expectedBuildArgValue {
-				t.Errorf("validateBuildOption failed for build-option %s. Expected to return %s, but returned %s",
-					test.buildOption, test.expectedBuildArgValue, res)
-			}
-
-			if isValid && test.buildOption == "dev" {
-				t.Errorf("validateBuildOption failed for build-option %s and unsupported language. Expected validation to fail, but it was successful",
-					test.buildOption)
-			}
-		})
-	}
-
-	os.RemoveAll("template")
 }

--- a/stack/schema.go
+++ b/stack/schema.go
@@ -47,6 +47,9 @@ type Function struct {
 
 	// Requests of resources requested by function
 	Requests *FunctionResources `yaml:"requests"`
+
+	// BuildOptions to determine native packages
+	BuildOptions []string `yaml:"build_options"`
 }
 
 // FunctionResources Memory and CPU


### PR DESCRIPTION
Initial work added the build-options into commands/build.go under preRunBuild.
In testing this was found to mean that --lang was having to be added to the
CLI even though it was already specified in the yaml.

This work has refactored the build-options work to move it into the builder package
at which point the language, whether from the CLI or yaml, is known and so negates the
need for the user to 'double supply'.

The basic flow is bring together all desired build-options, determine that they are all
valid for the current language, convert the build-options to a list of packages, deduplicate
the packages, convert to a build-arg of ADDITIONAL_PACKAGES= before appending any build-args
od the same name to the set.

Signed-off-by: rgee0 <richard@technologee.co.uk>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
